### PR TITLE
heartbeat api endpoint

### DIFF
--- a/onyx/api/heartbeat.py
+++ b/onyx/api/heartbeat.py
@@ -1,0 +1,19 @@
+from flask import (
+    Blueprint,
+)
+from onyx.environment import Environment
+
+
+hb = Blueprint('heartbeat', __name__, url_prefix='/')
+env = Environment.instance()
+
+
+@hb.route('__heartbeat__', methods=['GET'])
+def report():
+    """
+    Return OK to say the server works OK
+    """
+    return ''
+
+def register_routes(app):
+    app.register_blueprint(hb)

--- a/onyx/api/heartbeat.py
+++ b/onyx/api/heartbeat.py
@@ -15,5 +15,6 @@ def report():
     """
     return ''
 
+
 def register_routes(app):
     app.register_blueprint(hb)

--- a/onyx/webapp.py
+++ b/onyx/webapp.py
@@ -7,3 +7,6 @@ def setup_routes(app):
 
     import onyx.api.v3
     onyx.api.v3.register_routes(app)
+
+    import onyx.api.heartbeat
+    onyx.api.heartbeat.register_routes(app)

--- a/tests/api/test_heartbeat.py
+++ b/tests/api/test_heartbeat.py
@@ -1,0 +1,12 @@
+from flask import url_for
+from nose.tools import assert_equals
+from tests.base import BaseTestCase
+
+
+class TestHeartBeat(BaseTestCase):
+
+    def test_ok(self):
+        """
+        """
+        response = self.client.get(url_for('heartbeat.report'))
+        assert_equals(response.status_code, 200)


### PR DESCRIPTION
the heartbeat api endpoint is intended to be used by the ELB to know whether or not to put the webhead out of rotation
