### PR TITLE
Bug 1160366 - Remove response body on fetch redirect

### DIFF
--- a/onyx/api/v1.py
+++ b/onyx/api/v1.py
@@ -79,7 +79,9 @@ def fetch():
     if localized:
         # 303 hints to the client to always use GET for the redirect
         # ETag is handled by the directory link hosting server
-        response = make_response(redirect(localized, code=303))
+        resp = redirect(localized, code=303)
+        resp.data = ''
+        response = make_response(resp)
         env.log_dict(name="application", action="fetch_served", message={
             "ip": ip_addr,
             "ua": ua,

--- a/onyx/api/v2.py
+++ b/onyx/api/v2.py
@@ -64,7 +64,9 @@ def fetch(locale=None):
     if localized is not None:
         # 303 hints to the client to always use GET for the redirect
         # ETag is handled by the directory link hosting server
-        response = make_response(redirect(localized, code=303))
+        resp = redirect(localized, code=303)
+        resp.data = ''
+        response = make_response(resp)
         env.log_dict(name="application", action="fetch_served", message={
             "ip": ip_addrs,
             "ua": ua,

--- a/onyx/api/v3.py
+++ b/onyx/api/v3.py
@@ -43,7 +43,9 @@ def fetch(locale=None, channel=None):
     if localized is not None:
         # 303 hints to the client to always use GET for the redirect
         # ETag is handled by the directory link hosting server
-        response = make_response(redirect(localized, code=303))
+        resp = redirect(localized, code=303)
+        resp.data = ''
+        response = make_response(resp)
         env.log_dict(name="application", action="fetch_served", message={
             "ip": ip_addrs,
             "ua": ua,

--- a/tests/api/test_v1.py
+++ b/tests/api/test_v1.py
@@ -53,3 +53,4 @@ class TestNewtabServing(BaseTestCase):
                                     environ_base={"REMOTE_ADDR": "173.194.43.105"},
                                     data=json.dumps({'locale': 'en-US', 'directoryCount': {'organic': 1}}))
         assert_equals(response.status_code, 303)
+        assert_equals(int(response.headers.get('Content-Length')), 0)

--- a/tests/api/test_v1.py
+++ b/tests/api/test_v1.py
@@ -18,7 +18,7 @@ class TestNewtabServing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 400)
         assert_is_none(response.headers.get('Set-Cookie'))
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_missing_dircount(self):
         """
@@ -30,7 +30,7 @@ class TestNewtabServing(BaseTestCase):
                                     data=json.dumps({'locale': 'en-US'}))
         assert_equals(response.status_code, 400)
         assert_is_none(response.headers.get('Set-Cookie'))
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_unknown_locale(self):
         """
@@ -41,7 +41,7 @@ class TestNewtabServing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({'locale': 'zh-CN', 'directoryCount': {"organic": 1}}))
         assert_equals(response.status_code, 204)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_success(self):
         """
@@ -53,4 +53,4 @@ class TestNewtabServing(BaseTestCase):
                                     environ_base={"REMOTE_ADDR": "173.194.43.105"},
                                     data=json.dumps({'locale': 'en-US', 'directoryCount': {'organic': 1}}))
         assert_equals(response.status_code, 303)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)

--- a/tests/api/test_v2.py
+++ b/tests/api/test_v2.py
@@ -63,6 +63,7 @@ class TestNewtabServing(BaseTestCase):
                                     environ_base={"REMOTE_ADDR": "173.194.43.105"},
                                     data=json.dumps({'locale': 'en-US'}))
         assert_equals(response.status_code, 303)
+        assert_equals(response.content_length, 0)
 
 
 class TestClickPing(BaseTestCase):

--- a/tests/api/test_v2.py
+++ b/tests/api/test_v2.py
@@ -18,7 +18,7 @@ class TestNewtabServing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 400)
         assert_is_none(response.headers.get('Set-Cookie'))
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_unknown_locale(self):
         """
@@ -29,7 +29,7 @@ class TestNewtabServing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({'locale': 'zh-CN'}))
         assert_equals(response.status_code, 204)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_unknown_country(self):
         """
@@ -41,6 +41,7 @@ class TestNewtabServing(BaseTestCase):
                                     environ_base={"REMOTE_ADDR": "202.224.135.69"},
                                     data=json.dumps({'locale': 'en-US'}))
         assert_equals(response.status_code, 303)
+        assert_equals(response.content_length, 0)
 
     def test_empty_payload(self):
         """
@@ -51,7 +52,7 @@ class TestNewtabServing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({}))
         assert_equals(response.status_code, 400)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_success(self):
         """
@@ -76,6 +77,7 @@ class TestClickPing(BaseTestCase):
                                     content_type='application/json',
                                     headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
 
     def test_empty_payload(self):
         """
@@ -86,6 +88,7 @@ class TestClickPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({}))
         assert_equals(response.status_code, 200)
+        assert_equals(response.content_length, 0)
 
     def test_payload_meta(self):
         """
@@ -96,7 +99,7 @@ class TestClickPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({"data": "test"}))
         assert_equals(response.status_code, 200)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
 
 class TestViewPing(BaseTestCase):
@@ -109,6 +112,7 @@ class TestViewPing(BaseTestCase):
                                     content_type='application/json',
                                     headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
 
     def test_junk_payload(self):
         """
@@ -119,6 +123,7 @@ class TestViewPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data='"hfdsfdsjkl"')
         assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
 
     def test_payload_meta(self):
         """
@@ -129,4 +134,4 @@ class TestViewPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({"data": "test"}))
         assert_equals(response.status_code, 200)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)

--- a/tests/api/test_v3.py
+++ b/tests/api/test_v3.py
@@ -38,6 +38,7 @@ class TestNewtabServing(BaseTestCase):
             headers=[("User-Agent", "TestClient")],
             environ_base={"REMOTE_ADDR": "173.194.43.105"})
         assert_equals(response.status_code, 303)
+        assert_equals(response.content_length, 0)
 
 
 class TestClickPing(BaseTestCase):

--- a/tests/api/test_v3.py
+++ b/tests/api/test_v3.py
@@ -15,7 +15,7 @@ class TestNewtabServing(BaseTestCase):
             content_type='application/json',
             headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 204)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
     def test_unknown_country(self):
         """
@@ -27,6 +27,7 @@ class TestNewtabServing(BaseTestCase):
             headers=[("User-Agent", "TestClient")],
             environ_base={"REMOTE_ADDR": "202.224.135.69"})
         assert_equals(response.status_code, 303)
+        assert_equals(response.content_length, 0)
 
     def test_success(self):
         """
@@ -51,6 +52,7 @@ class TestClickPing(BaseTestCase):
                                     content_type='application/json',
                                     headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
 
     def test_empty_payload(self):
         """
@@ -61,6 +63,7 @@ class TestClickPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({}))
         assert_equals(response.status_code, 200)
+        assert_equals(response.content_length, 0)
 
     def test_payload_meta(self):
         """
@@ -71,7 +74,7 @@ class TestClickPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({"data": "test"}))
         assert_equals(response.status_code, 200)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)
 
 
 class TestViewPing(BaseTestCase):
@@ -84,6 +87,7 @@ class TestViewPing(BaseTestCase):
                                     content_type='application/json',
                                     headers=[("User-Agent", "TestClient")])
         assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
 
     def test_junk_payload(self):
         """
@@ -94,6 +98,7 @@ class TestViewPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data='"hfdsfdsjkl"')
         assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
 
     def test_payload_meta(self):
         """
@@ -104,4 +109,4 @@ class TestViewPing(BaseTestCase):
                                     headers=[("User-Agent", "TestClient")],
                                     data=json.dumps({"data": "test"}))
         assert_equals(response.status_code, 200)
-        assert_equals(int(response.headers.get('Content-Length')), 0)
+        assert_equals(response.content_length, 0)


### PR DESCRIPTION
save 250 bytes per request or so
tracked at https://bugzilla.mozilla.org/show_bug.cgi?id=1160366
