### PR TITLE
update gevent because of ssl issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==0.10.1
 Flask-Script==0.6.7
 Flask-Cors==2.0.1
-gevent==1.0.2
+gevent==1.1.0
 gunicorn==18.0
 pycrypto==2.6.1
 mock==1.0.1


### PR DESCRIPTION
an update to python in centos 7 broke gevent < 1.1

r? @ncloudioj 
