### PR TITLE
Add endpoint for activity stream mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ There are a few API endpoints we care about:
 * [/v3/links/view](#v3linksview)
 * [/v3/links/click](#v3linksclick)
 * [/v3/links/activity-stream](#v3linksactivity-stream)
+* [/v3/links/activity-stream-mobile](#v3linksactivity-stream-mobile)
 
 ## /v2/links/fetch/`locale`
 
@@ -167,6 +168,29 @@ Example Payload:
       "search": 0,  # indicates a search was performed
       "max_scroll_depth": 100,
       "click_position": 2,  #[TBD, index of object clicked on a click event or -1? or 2D coordinates e.g. 200x400?]
+      "total_bookmarks": 5,
+      "total_history_size": 1000,
+      "session_duration": 2000,
+      "unload_reason": "click"  # ["click", "search", "close", "unfocus"]
+    }
+
+## /v3/links/activity-stream-mobile
+
+The `activity-stream-mobile` endpoint captures any event takes place in the mobile Activity Stream devices.
+
+Method: POST
+
+Example Payload:
+
+    {
+      "client_id": "some_client_id",
+      "addon_version": "1.0",
+      "tab_id": 1,
+      "load_reason": "newtab",  #["newtab", "focus", "restore"]
+      "source": "activity_stream",  #["recent_links", "recent_bookmarks", "frecent_links", "top_sites", "spotlight"]
+      "search": 0,  # indicates a search was performed
+      "max_scroll_depth": 100,
+      "click_position": 2,
       "total_bookmarks": 5,
       "total_history_size": 1000,
       "session_duration": 2000,

--- a/onyx/api/v3.py
+++ b/onyx/api/v3.py
@@ -122,13 +122,9 @@ def click():
     return handle_ping("click", api_version="3")
 
 
-@links.route('/activity-stream', methods=['POST'])
-@env.statsd.timer('v3_links_activity_stream')
-def activity_stream():
-    """Log activity stream ping sent from Firefox on each session"""
+def handle_activity_stream_ping(ping_type, log_name):
     ip_addr = None
     ua = None
-    ping_type = 'activity_stream'
     action = None
 
     try:
@@ -154,11 +150,25 @@ def activity_stream():
         return Response('', content_type='application/json; charset=utf-8',
                         status=400)
 
-    env.log_dict(name="application", action=action, message=client_payload)
+    env.log_dict(name=log_name, action=action, message=client_payload)
 
     env.statsd.incr("{0}".format(ping_type))
     return Response('', content_type='application/json; charset=utf-8',
                     status=200)
+
+
+@links.route('/activity-stream', methods=['POST'])
+@env.statsd.timer('v3_links_activity_stream')
+def activity_stream():
+    """Log activity stream ping sent from Firefox on each session"""
+    return handle_activity_stream_ping("activity_stream", "application")
+
+
+@links.route('/activity-stream-mobile', methods=['POST'])
+@env.statsd.timer('v3_links_activity_stream_mobile')
+def activity_stream_mobile():
+    """Log activity stream ping sent from Firefox mobile devices on each session"""
+    return handle_activity_stream_ping("activity_stream_mobile", "activity_stream_mobile")
 
 
 def register_routes(app):

--- a/onyx/default_settings.py
+++ b/onyx/default_settings.py
@@ -66,6 +66,16 @@ class DefaultConfig(object):
                 'socktype': socket.SOCK_DGRAM,
             }
         },
+        'activity_stream_mobile': {
+            'handler': logging.handlers.SysLogHandler,
+            'format': '%(message)s',
+            'level': logging.INFO,
+            'params': {
+                'address': ('localhost', 514),
+                'facility': logging.handlers.SysLogHandler.LOG_LOCAL3,
+                'socktype': socket.SOCK_DGRAM,
+            }
+        },
         'console': {
             'handler': logging.StreamHandler,
             'level': logging.DEBUG,

--- a/tests/api/test_v3.py
+++ b/tests/api/test_v3.py
@@ -274,3 +274,28 @@ class TestActivityStreamPing(BaseTestCase):
                                     data=json.dumps({"data": "test", "action": "activity_stream_session"}))
         assert_equals(response.status_code, 200)
         assert_equals(response.content_length, 0)
+
+
+class TestActivityStreamMobilePing(BaseTestCase):
+    def test_missing_payload(self):
+        response = self.client.post(url_for('v3_links.activity_stream_mobile'),
+                                    content_type='application/json',
+                                    headers=[("User-Agent", "TestClient")])
+        assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
+
+    def test_junk_payload(self):
+        response = self.client.post(url_for('v3_links.activity_stream_mobile'),
+                                    content_type='application/json',
+                                    headers=[("User-Agent", "TestClient")],
+                                    data='"hfdsfdsjkl"')
+        assert_equals(response.status_code, 400)
+        assert_equals(response.content_length, 0)
+
+    def test_payload_meta(self):
+        response = self.client.post(url_for('v3_links.activity_stream_mobile'),
+                                    content_type='application/json',
+                                    headers=[("User-Agent", "TestClient")],
+                                    data=json.dumps({"data": "test", "action": "activity_stream_mobile_session"}))
+        assert_equals(response.status_code, 200)
+        assert_equals(response.content_length, 0)


### PR DESCRIPTION
A dedicated endpoint for Activity Stream mobile is added by this PR. Note that it also could be used by other purposes for the mobile Firefox other than A-S. 